### PR TITLE
Update build-vars

### DIFF
--- a/build-vars
+++ b/build-vars
@@ -41,7 +41,7 @@ cloud_init_user='CLOUD-INIT-USERNAME-HERE'
 scsihw='virtio-scsi-pci'
 
 # What to name your template. This is free form with no spaces and will be used for automation/deployments.
-template_name 'YOUR-TEMPLATE-NAME'
+template_name='YOUR-TEMPLATE-NAME'
 
 # Memory and CPU cores. These are overridden with image deployments or through the PVE interface.
 vm_mem='2048'


### PR DESCRIPTION
Missing '=' causes script to fail when run as variable is never assigned.